### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#MEMSCAN
+# MEMSCAN
 
 [![Build Status](https://travis-ci.org/hexploitable/MEMSCAN.svg?branch=master)](https://travis-ci.org/hexploitable/MEMSCAN)
 
@@ -8,19 +8,19 @@ As far as the scanner is concerned, I'm finished with it. I'm going to do a fina
 
 Tweet me: `@Hexploitable`
 
-##Building MEMSCAN
+## Building MEMSCAN
 To build MEMSCAN, you will need to have theos installed. Well, you don't really need it but it makes life easier.
 
 Once Theos is installed, simply navigate to the MEMSCAN folder in terminal and run:<br /><br />
 `make package install`
 
-##Usage
-###Dumping the memory of a process
+## Usage
+### Dumping the memory of a process
 1. Obtain the target process PID, using `ps`.
 2. Provide the PID to memscan:<br />
 `./memscan -p <PID> -d`
 
-###Finding objects in memory
+### Finding objects in memory
 
 1. Open your target app or process in a disassembler, grab first ~16 bytes (customise this number as you will) of the method you want to hook and these bytes will be your "signature".
 
@@ -39,7 +39,7 @@ e.g:
 4. MEMSCAN should then print the address where the needle is located in memory.
 
 
-##Resources
+## Resources
 There are some fantastic resources out there which can help you develop similar concepts or to improve on this utility.
 <br />
 The most useful resource was a book called "Mac OS X Internals: A Systems Approach" which even provides sample code snippets to help you.
@@ -47,7 +47,7 @@ The most useful resource was a book called "Mac OS X Internals: A Systems Approa
 <br />
 It's been brought to my attention there is another stack of tools which does similar things, called [Radare](https://github.com/radare/radare2), which you should check out as it's pretty cool.
 
-##Contact
+## Contact
 For any issues or concerns, contact me on Twitter: `@Hexploitable`.
 <br/>
 If you need more than 140 characters, open an issue here.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
